### PR TITLE
fix(lattice2latex): comment unused import

### DIFF
--- a/lattice2latex.py
+++ b/lattice2latex.py
@@ -1,7 +1,7 @@
 import lattice
 import json
 import argparse
-from IPython import embed
+# from IPython import embed
 import networkx as nx
 
 


### PR DESCRIPTION
This fixes running that file.

Is there a way to render it like in your paper?
![image](https://user-images.githubusercontent.com/5757359/45712149-3c898700-bb94-11e8-8ab9-fd7dd1fabfbe.png)

I ran the latex and got:
![image](https://user-images.githubusercontent.com/5757359/45712165-48754900-bb94-11e8-9dfd-f484ad95a3bb.png)
(Which is better than nothing, but is a mess)

What I ran:
```sh
python lattice.py -order_method soft -align_method soft -dataset data/dataset_small.json -minus 0.6 -lm_dictionary data/LM_coco.dict -lm_model data/LM_coco.pth -save_graph
python lattice2latex.py -original_dataset data/dataset_small.json -lattice_dataset data/dataset_soft_soft_0.60.json -lattice_index 1
```